### PR TITLE
refactor: rename `weight` to `intensity` in Events API and core engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ curl -X POST http://localhost:8080/api/v1/events \
       "src": "user:123",
       "dst": "topic:car-buying",
       "type": "chat",
-      "weight": 2.0
+      "intensity": 2.0
     },
     {
       "space": "user:123",
@@ -93,7 +93,7 @@ curl -X POST http://localhost:8080/api/v1/events \
       "src": "agent:planner",
       "dst": "tool:car-comparison",
       "type": "tool_use",
-      "weight": 1.0
+      "intensity": 1.0
     }
   ]'
 ```

--- a/core-engine/src/main/java/io/caudal/core/Event.java
+++ b/core-engine/src/main/java/io/caudal/core/Event.java
@@ -7,7 +7,7 @@ import java.util.Objects;
 public record Event(
     String src,
     String dst,
-    double weight,
+    double intensity,
     String type,
     Instant timestamp,
     Map<String, String> attrs
@@ -16,15 +16,15 @@ public record Event(
     public Event {
         Objects.requireNonNull(src, "src must not be null");
         Objects.requireNonNull(dst, "dst must not be null");
-        if (weight <= 0) {
-            throw new IllegalArgumentException("weight must be positive");
+        if (intensity <= 0) {
+            throw new IllegalArgumentException("intensity must be positive");
         }
         if (attrs == null) {
             attrs = Map.of();
         }
     }
 
-    public Event(String src, String dst, double weight) {
-        this(src, dst, weight, null, null, Map.of());
+    public Event(String src, String dst, double intensity) {
+        this(src, dst, intensity, null, null, Map.of());
     }
 }

--- a/core-engine/src/main/java/io/caudal/core/MemoryEngine.java
+++ b/core-engine/src/main/java/io/caudal/core/MemoryEngine.java
@@ -18,7 +18,7 @@ public final class MemoryEngine {
 
             applyDecay(edge, currentBucket, config.decayPerBucket());
 
-            edge.setScore(edge.score() + event.weight() * config.depositScale());
+            edge.setScore(edge.score() + event.intensity() * config.depositScale());
             edge.setLastUpdatedBucket(currentBucket);
             edge.incrementRawCount();
         }

--- a/core-engine/src/test/java/io/caudal/core/MemoryEngineTest.java
+++ b/core-engine/src/test/java/io/caudal/core/MemoryEngineTest.java
@@ -86,7 +86,7 @@ class MemoryEngineTest {
         }
 
         @Test
-        void reinforcement_weightScaling() {
+        void reinforcement_intensityScaling() {
             SpaceConfig config = new SpaceConfig(1000, 10000, 1e-9, 0.05, 2.0, 1.0);
             SpaceState space = new SpaceState("test", config);
 

--- a/examples/curl/demo.sh
+++ b/examples/curl/demo.sh
@@ -13,12 +13,12 @@ curl -s -X POST "$BASE/api/v1/events" \
   -d '{
     "space": "demo",
     "events": [
-      {"src": "user:alice", "dst": "topic:machine-learning", "weight": 3.0, "type": "interaction"},
-      {"src": "user:alice", "dst": "topic:python", "weight": 2.0, "type": "interaction"},
-      {"src": "user:bob", "dst": "topic:machine-learning", "weight": 5.0, "type": "interaction"},
-      {"src": "user:bob", "dst": "topic:data-pipelines", "weight": 1.0, "type": "interaction"},
-      {"src": "user:carol", "dst": "topic:python", "weight": 4.0, "type": "interaction"},
-      {"src": "user:carol", "dst": "topic:machine-learning", "weight": 1.0, "type": "interaction"}
+      {"src": "user:alice", "dst": "topic:machine-learning", "intensity": 3.0, "type": "interaction"},
+      {"src": "user:alice", "dst": "topic:python", "intensity": 2.0, "type": "interaction"},
+      {"src": "user:bob", "dst": "topic:machine-learning", "intensity": 5.0, "type": "interaction"},
+      {"src": "user:bob", "dst": "topic:data-pipelines", "intensity": 1.0, "type": "interaction"},
+      {"src": "user:carol", "dst": "topic:python", "intensity": 4.0, "type": "interaction"},
+      {"src": "user:carol", "dst": "topic:machine-learning", "intensity": 1.0, "type": "interaction"}
     ]
   }' | jq .
 

--- a/server/src/main/java/io/caudal/server/controller/EventController.java
+++ b/server/src/main/java/io/caudal/server/controller/EventController.java
@@ -40,7 +40,7 @@ public class EventController implements EventsApi {
                     .map(item -> new Event(
                             item.src(),
                             item.dst(),
-                            item.weight(),
+                            item.intensity(),
                             item.type(),
                             item.timestamp() != null ? Instant.parse(item.timestamp()) : null,
                             item.attrs() != null ? item.attrs() : Map.of()

--- a/server/src/main/java/io/caudal/server/dto/EventRequest.java
+++ b/server/src/main/java/io/caudal/server/dto/EventRequest.java
@@ -13,15 +13,15 @@ public record EventRequest(
     public record EventItem(
         @NotBlank String src,
         @NotBlank String dst,
-        double weight,
+        double intensity,
         String type,
         String timestamp,
         java.util.Map<String, String> attrs
     ) {
 
         public EventItem {
-            if (weight <= 0) {
-                weight = 1.0;
+            if (intensity <= 0) {
+                intensity = 1.0;
             }
         }
     }

--- a/server/src/main/java/io/caudal/server/persistence/PersistenceService.java
+++ b/server/src/main/java/io/caudal/server/persistence/PersistenceService.java
@@ -36,7 +36,7 @@ public class PersistenceService {
     }
 
     public void appendWal(String spaceId, List<EventRequest.EventItem> events) {
-        String sql = "INSERT INTO event_log (space_id, event_timestamp, src, dst, weight, type, attrs) " +
+        String sql = "INSERT INTO event_log (space_id, event_timestamp, src, dst, intensity, type, attrs) " +
             "VALUES (?, ?, ?, ?, ?, ?, ?)";
 
         List<Object[]> batchArgs = events.stream()
@@ -45,7 +45,7 @@ public class PersistenceService {
                 e.timestamp(),
                 e.src(),
                 e.dst(),
-                e.weight(),
+                e.intensity(),
                 e.type(),
                 e.attrs() != null ? toJson(e.attrs()) : null
             })
@@ -98,12 +98,12 @@ public class PersistenceService {
 
     public List<EventRequest.EventItem> replayWalAfter(String spaceId, Instant after) {
         return jdbc.query(
-            "SELECT src, dst, weight, type, event_timestamp, attrs FROM event_log " +
+            "SELECT src, dst, intensity, type, event_timestamp, attrs FROM event_log " +
                 "WHERE space_id = ? AND arrived_at > ? ORDER BY arrived_at",
             (rs, rowNum) -> new EventRequest.EventItem(
                 rs.getString("src"),
                 rs.getString("dst"),
-                rs.getDouble("weight"),
+                rs.getDouble("intensity"),
                 rs.getString("type"),
                 rs.getString("event_timestamp"),
                 null

--- a/server/src/main/java/io/caudal/server/service/RecoveryService.java
+++ b/server/src/main/java/io/caudal/server/service/RecoveryService.java
@@ -70,7 +70,7 @@ public class RecoveryService {
         if (!walEvents.isEmpty()) {
             List<Event> coreEvents = walEvents.stream()
                     .map(e -> new Event(
-                            e.src(), e.dst(), e.weight(), e.type(),
+                            e.src(), e.dst(), e.intensity(), e.type(),
                             e.timestamp() != null ? Instant.parse(e.timestamp()) : null,
                             e.attrs() != null ? e.attrs() : Map.of()
                     ))

--- a/server/src/main/resources/db/migration/V2__rename_weight_to_intensity.sql
+++ b/server/src/main/resources/db/migration/V2__rename_weight_to_intensity.sql
@@ -1,0 +1,1 @@
+ALTER TABLE event_log RENAME COLUMN weight TO intensity;

--- a/server/src/main/resources/openapi/caudal-api.yaml
+++ b/server/src/main/resources/openapi/caudal-api.yaml
@@ -99,11 +99,11 @@ paths:
               events:
                 - src: "user:123"
                   dst: "topic:car-buying"
-                  weight: 2.0
+                  intensity: 2.0
                   type: "chat"
                 - src: "agent:planner"
                   dst: "tool:car-comparison"
-                  weight: 1.0
+                  intensity: 1.0
                   type: "tool_use"
       responses:
         '202':
@@ -402,14 +402,15 @@ components:
             is reinforced by this event. Use the same namespacing convention
             as `src`.
           example: "topic:car-buying"
-        weight:
+        intensity:
           type: number
           format: double
           default: 1.0
           description: |
-            Reinforcement strength of this event. Higher values cause the
-            edge to gain more relevance per event. Typical range is
-            `0.1` to `10.0`. Defaults to `1.0` if omitted or non-positive.
+            Reinforcement intensity of this event — how impactful or
+            memorable it is. Higher values cause the edge to gain more
+            relevance per event. Typical range is `0.1` to `10.0`.
+            Defaults to `1.0` if omitted or non-positive.
           example: 2.0
         type:
           type: string
@@ -500,7 +501,7 @@ components:
             Current relevance score after time-based decay. Higher means
             more relevant right now. Scores are non-negative and decrease
             over time as interactions age. The absolute magnitude depends on
-            event weights and recency; compare scores within the same
+            event intensities and recency; compare scores within the same
             response to determine relative importance.
           example: 0.83
 
@@ -594,7 +595,7 @@ components:
           description: |
             Ordered list of entity identifiers along the path. The first
             element is always the `start` entity from the request. Each
-            subsequent element was reached by following the highest-weight
+            subsequent element was reached by following the highest-intensity
             outgoing edge probabilistically.
           items:
             type: string

--- a/server/src/test/java/io/caudal/server/controller/EventControllerTest.java
+++ b/server/src/test/java/io/caudal/server/controller/EventControllerTest.java
@@ -37,8 +37,8 @@ class EventControllerTest {
                     {
                       "space": "test-space",
                       "events": [
-                        {"src": "user:alice", "dst": "topic:java", "weight": 1.0, "type": "interaction"},
-                        {"src": "user:bob", "dst": "topic:spring", "weight": 2.0}
+                        {"src": "user:alice", "dst": "topic:java", "intensity": 1.0, "type": "interaction"},
+                        {"src": "user:bob", "dst": "topic:spring", "intensity": 2.0}
                       ]
                     }
                     """))
@@ -53,7 +53,7 @@ class EventControllerTest {
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("""
                     {
-                      "events": [{"src": "a", "dst": "b", "weight": 1.0}]
+                      "events": [{"src": "a", "dst": "b", "intensity": 1.0}]
                     }
                     """))
             .andExpect(status().isBadRequest());
@@ -80,7 +80,7 @@ class EventControllerTest {
                     {
                       "space": "focus-test",
                       "events": [
-                        {"src": "agent:1", "dst": "entity:foo", "weight": 5.0}
+                        {"src": "agent:1", "dst": "entity:foo", "intensity": 5.0}
                       ]
                     }
                     """))

--- a/server/src/test/java/io/caudal/server/controller/QueryControllerTest.java
+++ b/server/src/test/java/io/caudal/server/controller/QueryControllerTest.java
@@ -38,9 +38,9 @@ class QueryControllerTest {
                 {
                   "space": "qtest",
                   "events": [
-                    {"src": "a", "dst": "b", "weight": 3.0},
-                    {"src": "a", "dst": "c", "weight": 1.0},
-                    {"src": "b", "dst": "d", "weight": 2.0}
+                    {"src": "a", "dst": "b", "intensity": 3.0},
+                    {"src": "a", "dst": "c", "intensity": 1.0},
+                    {"src": "b", "dst": "d", "intensity": 2.0}
                   ]
                 }
                 """));

--- a/server/src/test/java/io/caudal/server/persistence/PersistenceIntegrationTest.java
+++ b/server/src/test/java/io/caudal/server/persistence/PersistenceIntegrationTest.java
@@ -65,7 +65,7 @@ class PersistenceIntegrationTest {
                     {
                       "space": "wal-test",
                       "events": [
-                        {"src": "x", "dst": "y", "weight": 1.0}
+                        {"src": "x", "dst": "y", "intensity": 1.0}
                       ]
                     }
                     """))
@@ -85,7 +85,7 @@ class PersistenceIntegrationTest {
                     {
                       "space": "snap-test",
                       "events": [
-                        {"src": "a", "dst": "b", "weight": 5.0}
+                        {"src": "a", "dst": "b", "intensity": 5.0}
                       ]
                     }
                     """))
@@ -107,9 +107,9 @@ class PersistenceIntegrationTest {
                     {
                       "space": "rt-test",
                       "events": [
-                        {"src": "agent:1", "dst": "topic:ml", "weight": 3.0},
-                        {"src": "agent:1", "dst": "topic:java", "weight": 1.0},
-                        {"src": "agent:2", "dst": "topic:ml", "weight": 2.0}
+                        {"src": "agent:1", "dst": "topic:ml", "intensity": 3.0},
+                        {"src": "agent:1", "dst": "topic:java", "intensity": 1.0},
+                        {"src": "agent:2", "dst": "topic:ml", "intensity": 2.0}
                       ]
                     }
                     """))


### PR DESCRIPTION
The `weight` field was semantically ambiguous — it could mean connection strength, frequency, or importance. Renaming to `intensity` makes the API self-documenting: "how impactful/memorable is this event?" This mirrors how biological memory works where emotional arousal modulates consolidation.

The rename spans the domain model, DTO, controller, persistence layer, OpenAPI spec, tests, docs, and includes a Flyway V2 migration. Local variables in MemoryEngine.pathways() (weights/totalWeight) are preserved as they represent a different concept (edge scores for probabilistic selection).