### PR TITLE
feat: Adding modulation

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -24,7 +24,12 @@
       "Bash(docker compose:*)",
       "Bash(docker-compose:*)",
       "Bash(./mvnw test:*)",
-      "Bash(mvn:*)"
+      "Bash(mvn:*)",
+      "Bash(git checkout:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(git push:*)",
+      "WebFetch(domain:raw.githubusercontent.com)"
     ]
   }
 }

--- a/.claude/skills/caudal-attention/SKILL.md
+++ b/.claude/skills/caudal-attention/SKILL.md
@@ -169,6 +169,56 @@ Use pathway results to:
 - Understand why a topic is relevant (trace the path back)
 - Find non-obvious dependencies or related concepts
 
+## When to modulate attention
+
+Sometimes the right response isn't to emit more events — it's to directly
+control what gets attention. Use modulations when:
+
+| Situation | Action |
+|-----------|--------|
+| User says "let's move on from X" | Suppress X: `{"entity": "topic:X", "attention": 0.1, "decay": 50}` |
+| User explicitly prioritizes Y | Amplify Y: `{"entity": "topic:Y", "attention": 3.0, "decay": 50}` |
+| A topic keeps surfacing but is no longer relevant | Suppress it: `{"entity": "topic:stale", "attention": 0.0}` |
+| User returns to a previously-suppressed topic | Reset it: `{"entity": "topic:X", "attention": 1.0}` |
+
+**Embed modulations in your event calls** for zero extra latency:
+
+```bash
+curl -s -X POST "$CAUDAL_URL/api/v1/events" \
+  -H "Authorization: Bearer $CAUDAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "space": "'$SPACE'",
+    "events": [
+      {"src": "user:alice", "dst": "topic:math", "intensity": 5.0, "type": "discussion"}
+    ],
+    "modulations": [
+      {"entity": "topic:bikes", "attention": 0.1, "decay": 50}
+    ]
+  }'
+```
+
+Or use the standalone endpoint when you only need to steer attention:
+
+```bash
+curl -s -X POST "$CAUDAL_URL/api/v1/modulate" \
+  -H "Authorization: Bearer $CAUDAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "space": "'$SPACE'",
+    "modulations": [
+      {"entity": "topic:bikes", "attention": 0.1, "decay": 50},
+      {"entity": "topic:math", "attention": 3.0, "decay": 50}
+    ]
+  }'
+```
+
+**Key principles:**
+- Modulations are **top-down** — they don't change the memory, only what surfaces
+- A `decay` of 50 means the modulation fades to half-strength after 50 events
+- Omit `decay` (or set to 0) for persistent modulation until explicitly reset
+- Setting `attention: 1.0` removes the modulation entirely
+
 ## Integration pattern
 
 ### Setup: Check if Caudal is available

--- a/.claude/skills/caudal-attention/references/api-quick-ref.md
+++ b/.claude/skills/caudal-attention/references/api-quick-ref.md
@@ -8,7 +8,8 @@ All endpoints require: `Authorization: Bearer $CAUDAL_API_KEY`
 
 ## POST /events — Emit interaction events
 
-The only write operation. Everything else is derived.
+The primary write operation. Optionally includes attention modulations for
+zero-latency top-down control.
 
 **Request:**
 ```json
@@ -26,11 +27,18 @@ The only write operation. Everything else is derived.
         "sessionId": "sess-abc"
       }
     }
+  ],
+  "modulations": [
+    {
+      "entity": "topic:old-stuff",
+      "attention": 0.1,
+      "decay": 50
+    }
   ]
 }
 ```
 
-**Fields:**
+**Event fields:**
 
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
@@ -42,6 +50,15 @@ The only write operation. Everything else is derived.
 | `events[].type` | no | null | Semantic label (chat, edit, tool_use, etc.) |
 | `events[].timestamp` | no | null | ISO-8601 original occurrence time (for auditing) |
 | `events[].attrs` | no | null | Free-form key-value metadata |
+
+**Modulation fields (optional):**
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `modulations` | no | — | Array of attention modulations to apply atomically with events |
+| `modulations[].entity` | yes | — | Entity to modulate (e.g. `topic:bikes`) |
+| `modulations[].attention` | yes | — | Multiplier: `0.0`=suppress, `1.0`=reset, `>1.0`=amplify |
+| `modulations[].decay` | no | 0 | Events until half-strength. `0`=persistent |
 
 **Response:** `202 Accepted`
 ```json
@@ -156,6 +173,51 @@ connections that single-hop queries cannot surface.
   "asOf": "2026-03-06T10:06:00Z"
 }
 ```
+
+---
+
+## POST /modulate — Suppress or amplify entity attention
+
+Directly control which entities surface in query results without changing the
+underlying memory. Use this when you only need to steer attention (no events
+to emit). For zero extra latency, prefer embedding modulations in `POST /events`.
+
+**Request:**
+```json
+{
+  "space": "project:my-app",
+  "modulations": [
+    {"entity": "topic:bikes", "attention": 0.1, "decay": 50},
+    {"entity": "topic:math", "attention": 3.0, "decay": 50}
+  ]
+}
+```
+
+**Fields:**
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `space` | yes | — | Space containing the entities |
+| `modulations` | yes | — | Array of modulations (at least one) |
+| `modulations[].entity` | yes | — | Entity to modulate |
+| `modulations[].attention` | yes | — | Multiplier: `0.0`=fully suppress, `0.1`=strongly suppress, `1.0`=reset (remove modulation), `3.0`=triple score |
+| `modulations[].decay` | no | 0 | Number of events until the modulation fades to half-strength. `0`=persistent until explicitly reset |
+
+**Response:** `200 OK`
+```json
+{
+  "applied": 2,
+  "asOf": "2026-03-06T10:06:00Z"
+}
+```
+
+**When to use modulate vs. embedded modulations:**
+
+| Scenario | Approach |
+|----------|----------|
+| Emitting events AND steering attention | Embed `modulations` in `POST /events` |
+| Only steering attention (no new events) | Use `POST /modulate` |
+| User says "stop thinking about X" | Either — whichever fits your current call |
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ## [Unreleased]
 
 ### Added
+- Attention modulation: top-down control to suppress or amplify entity relevance
+  - Embedded in POST /events via optional `modulations` field (zero extra latency)
+  - Standalone POST /modulate endpoint
+  - Event-count-based decay (half-life model)
+  - Affects focus, next, and pathways queries
+  - Persisted in snapshots for recovery
 - Core memory engine with decay, reinforcement, ranking, and pruning
 - REST API: POST /events, GET /focus, GET /next, POST /pathways
 - API key authentication (Bearer/Token)

--- a/README.md
+++ b/README.md
@@ -198,6 +198,47 @@ Use cases:
 
 This enables agents to discover non‑obvious connections between entities — useful for proactive suggestions, root‑cause analysis, and planning across multiple domains.
 
+### 5) Modulate attention (suppress or amplify)
+
+Sometimes you need to tell Caudal "stop thinking about X, focus on Y" without erasing the memory of X. Attention modulation lets you suppress or amplify how much an entity appears in query results.
+
+```bash
+# Inline with events (recommended — zero extra latency):
+curl -X POST http://localhost:8080/api/v1/events \
+  -H "Authorization: Bearer <api_key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "space": "user:123",
+    "events": [
+      {"src": "user:123", "dst": "topic:math", "intensity": 3.0}
+    ],
+    "modulations": [
+      {"entity": "topic:bikes", "attention": 0.1, "decay": 50},
+      {"entity": "topic:math", "attention": 3.0, "decay": 50}
+    ]
+  }'
+
+# Or standalone:
+curl -X POST http://localhost:8080/api/v1/modulate \
+  -H "Authorization: Bearer <api_key>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "space": "user:123",
+    "modulations": [
+      {"entity": "topic:bikes", "attention": 0.1, "decay": 50}
+    ]
+  }'
+```
+
+| Attention value | Effect |
+|----------------|--------|
+| `0.0` | Fully suppress — entity disappears from results |
+| `0.1` | Strongly suppress — 10% of normal |
+| `1.0` | Normal (resets any modulation) |
+| `3.0` | Triple the score |
+
+The `decay` field controls how many events until the modulation fades to half strength. Omit it for a persistent modulation.
+
 ---
 
 ## Why this improves agents
@@ -231,6 +272,7 @@ Base path: `/api/v1`
 * `GET /focus?space=&k=` — ranked items that matter now
 * `GET /next?space=&src=&k=` — ranked next hops from an entity
 * `POST /pathways` — multi‑hop associations via sampled walks
+* `POST /modulate` — suppress or amplify entity attention
 
 Auth: `Authorization: Bearer <api_key>` (or `Token <api_key>`). Dev mode can disable auth.
 

--- a/core-engine/src/main/java/io/caudal/core/MemoryEngine.java
+++ b/core-engine/src/main/java/io/caudal/core/MemoryEngine.java
@@ -24,6 +24,22 @@ public final class MemoryEngine {
         }
 
         prune(space, currentBucket);
+        space.incrementEventCounter(events.size());
+        pruneModulations(space);
+    }
+
+    public void applyModulations(SpaceState space, List<Modulation> modulations) {
+        long currentCount = space.eventCounter();
+        for (Modulation mod : modulations) {
+            if (Math.abs(mod.attention() - 1.0) < 1e-9) {
+                space.removeModulation(mod.entity());
+            } else {
+                Modulation resolved = new Modulation(
+                    mod.entity(), mod.attention(), mod.decay(), currentCount
+                );
+                space.putModulation(resolved);
+            }
+        }
     }
 
     public List<FocusItem> focus(SpaceState space, int k, long currentBucket) {
@@ -38,7 +54,11 @@ public final class MemoryEngine {
         }
 
         return nodeScores.entrySet().stream()
-            .map(e -> new FocusItem(e.getKey(), e.getValue()))
+            .map(e -> {
+                double modulated = e.getValue() * effectiveAttention(space, e.getKey());
+                return new FocusItem(e.getKey(), modulated);
+            })
+            .filter(item -> item.score() > 0)
             .sorted()
             .limit(k)
             .toList();
@@ -54,8 +74,10 @@ public final class MemoryEngine {
             .map(key -> {
                 EdgeState edge = space.getEdge(key);
                 double decayed = decayedScore(edge, currentBucket, space.config().decayPerBucket());
-                return new NextHopItem(key.dst(), decayed);
+                double modulated = decayed * effectiveAttention(space, key.dst());
+                return new NextHopItem(key.dst(), modulated);
             })
+            .filter(item -> item.score() > 0)
             .sorted()
             .limit(k)
             .toList();
@@ -83,10 +105,9 @@ public final class MemoryEngine {
                 double totalWeight = 0;
                 for (EdgeKey key : outgoing) {
                     EdgeState edge = space.getEdge(key);
-                    double w = Math.pow(
-                        decayedScore(edge, currentBucket, space.config().decayPerBucket()),
-                        alpha
-                    );
+                    double raw = decayedScore(edge, currentBucket, space.config().decayPerBucket());
+                    double modulated = raw * effectiveAttention(space, key.dst());
+                    double w = Math.pow(Math.max(modulated, 0), alpha);
                     weights.add(w);
                     totalWeight += w;
                 }
@@ -141,7 +162,14 @@ public final class MemoryEngine {
             })
             .toList();
 
-        return new SpaceSnapshot(space.spaceId(), currentBucket, edgeData);
+        List<SpaceSnapshot.ModulationData> modData = space.modulations().values().stream()
+            .filter(m -> !m.isNeutral(space.eventCounter(), 0.001))
+            .map(m -> new SpaceSnapshot.ModulationData(
+                m.entity(), m.attention(), m.decay(), m.appliedAtEventCount()
+            ))
+            .toList();
+
+        return new SpaceSnapshot(space.spaceId(), currentBucket, edgeData, modData, space.eventCounter());
     }
 
     public SpaceState restore(SpaceSnapshot snap, SpaceConfig config) {
@@ -152,6 +180,14 @@ public final class MemoryEngine {
             edge.setScore(ed.score());
             edge.setLastUpdatedBucket(ed.lastUpdatedBucket());
         }
+        if (snap.modulations() != null) {
+            for (SpaceSnapshot.ModulationData md : snap.modulations()) {
+                space.putModulation(new Modulation(
+                    md.entity(), md.attention(), md.decay(), md.appliedAtEventCount()
+                ));
+            }
+        }
+        space.incrementEventCounter((int) snap.eventCounter());
         return space;
     }
 
@@ -170,6 +206,22 @@ public final class MemoryEngine {
             return edge.score();
         }
         return edge.score() * Math.pow(1.0 - decayPerBucket, delta);
+    }
+
+    private double effectiveAttention(SpaceState space, String entity) {
+        Modulation mod = space.modulations().get(entity);
+        if (mod == null) {
+            return 1.0;
+        }
+        return mod.effectiveAttention(space.eventCounter());
+    }
+
+    private void pruneModulations(SpaceState space) {
+        List<String> toRemove = space.modulations().entrySet().stream()
+            .filter(e -> e.getValue().isNeutral(space.eventCounter(), 0.001))
+            .map(Map.Entry::getKey)
+            .toList();
+        toRemove.forEach(space::removeModulation);
     }
 
     private void prune(SpaceState space, long currentBucket) {

--- a/core-engine/src/main/java/io/caudal/core/Modulation.java
+++ b/core-engine/src/main/java/io/caudal/core/Modulation.java
@@ -1,0 +1,33 @@
+package io.caudal.core;
+
+import java.util.Objects;
+
+public record Modulation(
+    String entity,
+    double attention,
+    long decay,
+    long appliedAtEventCount
+) {
+
+    public Modulation {
+        Objects.requireNonNull(entity, "entity must not be null");
+        if (attention < 0) {
+            throw new IllegalArgumentException("attention must be non-negative");
+        }
+    }
+
+    public double effectiveAttention(long currentEventCount) {
+        if (decay <= 0) {
+            return attention;
+        }
+        long delta = currentEventCount - appliedAtEventCount;
+        if (delta <= 0) {
+            return attention;
+        }
+        return 1.0 + (attention - 1.0) * Math.pow(0.5, (double) delta / decay);
+    }
+
+    public boolean isNeutral(long currentEventCount, double epsilon) {
+        return Math.abs(effectiveAttention(currentEventCount) - 1.0) < epsilon;
+    }
+}

--- a/core-engine/src/main/java/io/caudal/core/SpaceSnapshot.java
+++ b/core-engine/src/main/java/io/caudal/core/SpaceSnapshot.java
@@ -5,8 +5,14 @@ import java.util.List;
 public record SpaceSnapshot(
         String spaceId,
         long bucket,
-        List<EdgeData> edges
+        List<EdgeData> edges,
+        List<ModulationData> modulations,
+        long eventCounter
 ) {
+
+    public SpaceSnapshot(String spaceId, long bucket, List<EdgeData> edges) {
+        this(spaceId, bucket, edges, List.of(), 0);
+    }
 
     public record EdgeData(
             String src,
@@ -14,5 +20,12 @@ public record SpaceSnapshot(
             double score,
             long lastUpdatedBucket,
             long rawCount
+    ) {}
+
+    public record ModulationData(
+            String entity,
+            double attention,
+            long decay,
+            long appliedAtEventCount
     ) {}
 }

--- a/core-engine/src/main/java/io/caudal/core/SpaceState.java
+++ b/core-engine/src/main/java/io/caudal/core/SpaceState.java
@@ -12,12 +12,16 @@ public final class SpaceState {
     private final SpaceConfig config;
     private final Map<EdgeKey, EdgeState> edges;
     private final Map<String, List<EdgeKey>> outgoing;
+    private final Map<String, Modulation> modulations;
+    private long eventCounter;
 
     public SpaceState(String spaceId, SpaceConfig config) {
         this.spaceId = spaceId;
         this.config = config;
         this.edges = new HashMap<>();
         this.outgoing = new HashMap<>();
+        this.modulations = new HashMap<>();
+        this.eventCounter = 0;
     }
 
     public String spaceId() {
@@ -70,5 +74,25 @@ public final class SpaceState {
 
     public Map<String, List<EdgeKey>> outgoing() {
         return Collections.unmodifiableMap(outgoing);
+    }
+
+    public long eventCounter() {
+        return eventCounter;
+    }
+
+    public void incrementEventCounter(int count) {
+        this.eventCounter += count;
+    }
+
+    public Map<String, Modulation> modulations() {
+        return Collections.unmodifiableMap(modulations);
+    }
+
+    public void putModulation(Modulation mod) {
+        modulations.put(mod.entity(), mod);
+    }
+
+    public void removeModulation(String entity) {
+        modulations.remove(entity);
     }
 }

--- a/core-engine/src/test/java/io/caudal/core/MemoryEngineTest.java
+++ b/core-engine/src/test/java/io/caudal/core/MemoryEngineTest.java
@@ -292,4 +292,180 @@ class MemoryEngineTest {
             assertThat(restoredFocus).isEqualTo(originalFocus);
         }
     }
+
+    // --- Modulation ---
+
+    @Nested
+    class ModulationTests {
+
+        @Test
+        void modulation_suppressesEntityInFocus() {
+            SpaceState space = new SpaceState("test", SpaceConfig.DEFAULT);
+            engine.applyEvents(space, List.of(
+                    new Event("a", "bikes", 5.0),
+                    new Event("a", "math", 5.0)
+            ), 0);
+
+            List<FocusItem> before = engine.focus(space, 10, 0);
+            double bikesScoreBefore = before.stream()
+                    .filter(i -> i.id().equals("bikes")).findFirst().get().score();
+            double mathScoreBefore = before.stream()
+                    .filter(i -> i.id().equals("math")).findFirst().get().score();
+            assertThat(bikesScoreBefore).isCloseTo(mathScoreBefore, within(1e-10));
+
+            engine.applyModulations(space, List.of(
+                    new Modulation("bikes", 0.1, 0, 0)
+            ));
+
+            List<FocusItem> after = engine.focus(space, 10, 0);
+            double bikesScoreAfter = after.stream()
+                    .filter(i -> i.id().equals("bikes")).findFirst().get().score();
+            double mathScoreAfter = after.stream()
+                    .filter(i -> i.id().equals("math")).findFirst().get().score();
+
+            assertThat(bikesScoreAfter).isCloseTo(bikesScoreBefore * 0.1, within(1e-10));
+            assertThat(mathScoreAfter).isCloseTo(mathScoreBefore, within(1e-10));
+        }
+
+        @Test
+        void modulation_amplifiesEntityInFocus() {
+            SpaceState space = new SpaceState("test", SpaceConfig.DEFAULT);
+            engine.applyEvents(space, List.of(new Event("a", "math", 2.0)), 0);
+
+            double scoreBefore = engine.focus(space, 10, 0).stream()
+                    .filter(i -> i.id().equals("math")).findFirst().get().score();
+
+            engine.applyModulations(space, List.of(
+                    new Modulation("math", 3.0, 0, 0)
+            ));
+
+            double scoreAfter = engine.focus(space, 10, 0).stream()
+                    .filter(i -> i.id().equals("math")).findFirst().get().score();
+
+            assertThat(scoreAfter).isCloseTo(scoreBefore * 3.0, within(1e-10));
+        }
+
+        @Test
+        void modulation_decaysTowardNeutral() {
+            SpaceState space = new SpaceState("test", SpaceConfig.DEFAULT);
+            engine.applyEvents(space, List.of(new Event("a", "bikes", 5.0)), 0);
+
+            engine.applyModulations(space, List.of(
+                    new Modulation("bikes", 0.0, 10, 0)
+            ));
+
+            // Apply 10 more events to advance event counter by 10
+            engine.applyEvents(space, List.of(
+                    new Event("x", "y", 1.0), new Event("x", "y", 1.0),
+                    new Event("x", "y", 1.0), new Event("x", "y", 1.0),
+                    new Event("x", "y", 1.0), new Event("x", "y", 1.0),
+                    new Event("x", "y", 1.0), new Event("x", "y", 1.0),
+                    new Event("x", "y", 1.0), new Event("x", "y", 1.0)
+            ), 0);
+
+            Modulation mod = space.modulations().values().stream()
+                    .filter(m -> m.entity().equals("bikes")).findFirst().orElseThrow();
+            double eff = mod.effectiveAttention(space.eventCounter());
+            // appliedAtEventCount = 1 (after first event), currentEventCount = 11, delta = 10
+            assertThat(eff).isCloseTo(0.5, within(1e-10));
+        }
+
+        @Test
+        void modulation_resetWithAttentionOne() {
+            SpaceState space = new SpaceState("test", SpaceConfig.DEFAULT);
+            engine.applyEvents(space, List.of(new Event("a", "bikes", 5.0)), 0);
+
+            engine.applyModulations(space, List.of(
+                    new Modulation("bikes", 0.1, 0, 0)
+            ));
+            assertThat(space.modulations()).containsKey("bikes");
+
+            engine.applyModulations(space, List.of(
+                    new Modulation("bikes", 1.0, 0, 0)
+            ));
+            assertThat(space.modulations()).doesNotContainKey("bikes");
+        }
+
+        @Test
+        void modulation_affectsNextHop() {
+            SpaceState space = new SpaceState("test", SpaceConfig.DEFAULT);
+            engine.applyEvents(space, List.of(
+                    new Event("a", "bikes", 5.0),
+                    new Event("a", "math", 5.0)
+            ), 0);
+
+            engine.applyModulations(space, List.of(
+                    new Modulation("bikes", 0.0, 0, 0)
+            ));
+
+            List<NextHopItem> items = engine.next(space, "a", 10, 0);
+            assertThat(items).noneMatch(i -> i.id().equals("bikes"));
+            assertThat(items).anyMatch(i -> i.id().equals("math"));
+        }
+
+        @Test
+        void modulation_affectsPathways() {
+            SpaceState space = new SpaceState("test", SpaceConfig.DEFAULT);
+            engine.applyEvents(space, List.of(
+                    new Event("a", "bikes", 100.0),
+                    new Event("a", "math", 1.0)
+            ), 0);
+
+            PathwayResult r1 = engine.pathways(space, "a", 100, 1, 10, 42L, 0);
+            assertThat(r1.topEntities().getFirst().id()).isEqualTo("bikes");
+
+            engine.applyModulations(space, List.of(
+                    new Modulation("bikes", 0.0, 0, 0)
+            ));
+
+            PathwayResult r2 = engine.pathways(space, "a", 100, 1, 10, 42L, 0);
+            assertThat(r2.topEntities()).allMatch(e -> !e.id().equals("bikes"));
+        }
+
+        @Test
+        void modulation_persistsInSnapshot() {
+            SpaceState space = new SpaceState("test", SpaceConfig.DEFAULT);
+            engine.applyEvents(space, List.of(new Event("a", "b", 1.0)), 0);
+            engine.applyModulations(space, List.of(
+                    new Modulation("b", 2.5, 100, 0)
+            ));
+
+            SpaceSnapshot snap = engine.snapshot(space, 0);
+            SpaceState restored = engine.restore(snap, SpaceConfig.DEFAULT);
+
+            assertThat(restored.modulations()).containsKey("b");
+            assertThat(restored.eventCounter()).isEqualTo(space.eventCounter());
+
+            List<FocusItem> originalFocus = engine.focus(space, 10, 0);
+            List<FocusItem> restoredFocus = engine.focus(restored, 10, 0);
+            assertThat(restoredFocus).isEqualTo(originalFocus);
+        }
+
+        @Test
+        void modulation_zeroAttention_fullyIgnoresEntity() {
+            SpaceState space = new SpaceState("test", SpaceConfig.DEFAULT);
+            engine.applyEvents(space, List.of(new Event("a", "bikes", 10.0)), 0);
+
+            engine.applyModulations(space, List.of(
+                    new Modulation("bikes", 0.0, 0, 0)
+            ));
+
+            List<FocusItem> items = engine.focus(space, 10, 0);
+            assertThat(items).noneMatch(i -> i.id().equals("bikes"));
+        }
+
+        @Test
+        void eventCounter_incrementsByEventCount() {
+            SpaceState space = new SpaceState("test", SpaceConfig.DEFAULT);
+            assertThat(space.eventCounter()).isEqualTo(0);
+
+            engine.applyEvents(space, List.of(
+                    new Event("a", "b", 1.0),
+                    new Event("c", "d", 1.0),
+                    new Event("e", "f", 1.0)
+            ), 0);
+
+            assertThat(space.eventCounter()).isEqualTo(3);
+        }
+    }
 }

--- a/core-engine/src/test/java/io/caudal/core/ModulationTest.java
+++ b/core-engine/src/test/java/io/caudal/core/ModulationTest.java
@@ -1,0 +1,57 @@
+package io.caudal.core;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.within;
+
+import org.junit.jupiter.api.Test;
+
+class ModulationTest {
+
+    @Test
+    void persistent_modulation_neverDecays() {
+        Modulation mod = new Modulation("x", 0.1, 0, 0);
+        assertThat(mod.effectiveAttention(0)).isEqualTo(0.1);
+        assertThat(mod.effectiveAttention(1000)).isEqualTo(0.1);
+        assertThat(mod.effectiveAttention(1_000_000)).isEqualTo(0.1);
+    }
+
+    @Test
+    void decaying_modulation_halflife() {
+        Modulation mod = new Modulation("x", 0.0, 100, 0);
+        // At 0 events: full suppression
+        assertThat(mod.effectiveAttention(0)).isCloseTo(0.0, within(1e-10));
+        // At 100 events: 1.0 + (0.0 - 1.0) * 0.5^(100/100) = 0.5
+        assertThat(mod.effectiveAttention(100)).isCloseTo(0.5, within(1e-10));
+        // At 200 events: 1.0 + (0.0 - 1.0) * 0.5^(200/100) = 0.75
+        assertThat(mod.effectiveAttention(200)).isCloseTo(0.75, within(1e-10));
+    }
+
+    @Test
+    void amplifying_modulation_decays_toward_neutral() {
+        Modulation mod = new Modulation("x", 5.0, 50, 0);
+        // At 0 events: should be 5.0
+        assertThat(mod.effectiveAttention(0)).isCloseTo(5.0, within(1e-10));
+        // At 50 events: 1.0 + (5.0 - 1.0) * 0.5^(50/50) = 1.0 + 2.0 = 3.0
+        assertThat(mod.effectiveAttention(50)).isCloseTo(3.0, within(1e-10));
+    }
+
+    @Test
+    void isNeutral_detectsDecayedModulation() {
+        Modulation mod = new Modulation("x", 0.0, 10, 0);
+        assertThat(mod.isNeutral(0, 0.001)).isFalse();
+        assertThat(mod.isNeutral(1000, 0.001)).isTrue();
+    }
+
+    @Test
+    void negativeAttention_rejected() {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> new Modulation("x", -1.0, 0, 0));
+    }
+
+    @Test
+    void nullEntity_rejected() {
+        org.assertj.core.api.Assertions.assertThatNullPointerException()
+                .isThrownBy(() -> new Modulation(null, 1.0, 0, 0));
+    }
+}

--- a/server/pom.xml
+++ b/server/pom.xml
@@ -134,6 +134,9 @@
                                 <importMapping>PathwayRequest=io.caudal.server.dto.PathwayRequest</importMapping>
                                 <importMapping>PathwayResponse=io.caudal.server.dto.PathwayResponse</importMapping>
                                 <importMapping>PathItem=io.caudal.server.dto.PathwayResponse.PathItem</importMapping>
+                                <importMapping>ModulationItem=io.caudal.server.dto.ModulationItem</importMapping>
+                                <importMapping>ModulateRequest=io.caudal.server.dto.ModulateRequest</importMapping>
+                                <importMapping>ModulateResponse=io.caudal.server.dto.ModulateResponse</importMapping>
                                 <importMapping>ErrorResponse=java.util.Map</importMapping>
                             </importMappings>
                         </configuration>

--- a/server/src/main/java/io/caudal/server/controller/EventController.java
+++ b/server/src/main/java/io/caudal/server/controller/EventController.java
@@ -1,9 +1,12 @@
 package io.caudal.server.controller;
 
 import io.caudal.core.Event;
+import io.caudal.core.Modulation;
 import io.caudal.server.api.EventsApi;
 import io.caudal.server.dto.EventRequest;
 import io.caudal.server.dto.EventResponse;
+import io.caudal.server.dto.ModulateRequest;
+import io.caudal.server.dto.ModulateResponse;
 import io.caudal.server.persistence.PersistenceService;
 import io.caudal.server.service.SpaceManager;
 import io.micrometer.core.instrument.Counter;
@@ -47,7 +50,15 @@ public class EventController implements EventsApi {
                     ))
                     .toList();
 
-            long bucket = spaceManager.applyEvents(request.space(), coreEvents);
+            List<Modulation> coreModulations = null;
+            if (request.modulations() != null && !request.modulations().isEmpty()) {
+                coreModulations = request.modulations().stream()
+                        .map(m -> new Modulation(m.entity(), m.attention(), m.decay(), 0))
+                        .toList();
+            }
+
+            long bucket = spaceManager.applyEventsAndModulations(
+                    request.space(), coreEvents, coreModulations);
 
             persistence.appendWal(request.space(), request.events());
 
@@ -56,5 +67,17 @@ public class EventController implements EventsApi {
             String asOf = spaceManager.clock().toInstant(bucket).toString();
             return ResponseEntity.accepted().body(new EventResponse(coreEvents.size(), asOf));
         });
+    }
+
+    @Override
+    public ResponseEntity<ModulateResponse> modulate(ModulateRequest request) {
+        List<Modulation> coreModulations = request.modulations().stream()
+                .map(m -> new Modulation(m.entity(), m.attention(), m.decay(), 0))
+                .toList();
+
+        spaceManager.applyModulations(request.space(), coreModulations);
+
+        String asOf = spaceManager.clock().toInstant(spaceManager.clock().nowBucket()).toString();
+        return ResponseEntity.ok(new ModulateResponse(coreModulations.size(), asOf));
     }
 }

--- a/server/src/main/java/io/caudal/server/dto/EventRequest.java
+++ b/server/src/main/java/io/caudal/server/dto/EventRequest.java
@@ -7,7 +7,8 @@ import java.util.List;
 
 public record EventRequest(
     @NotBlank String space,
-    @NotEmpty @Valid List<EventItem> events
+    @NotEmpty @Valid List<EventItem> events,
+    @Valid List<ModulationItem> modulations
 ) {
 
     public record EventItem(

--- a/server/src/main/java/io/caudal/server/dto/ModulateRequest.java
+++ b/server/src/main/java/io/caudal/server/dto/ModulateRequest.java
@@ -1,0 +1,11 @@
+package io.caudal.server.dto;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import java.util.List;
+
+public record ModulateRequest(
+    @NotBlank String space,
+    @NotEmpty @Valid List<ModulationItem> modulations
+) {}

--- a/server/src/main/java/io/caudal/server/dto/ModulateResponse.java
+++ b/server/src/main/java/io/caudal/server/dto/ModulateResponse.java
@@ -1,0 +1,3 @@
+package io.caudal.server.dto;
+
+public record ModulateResponse(int applied, String asOf) {}

--- a/server/src/main/java/io/caudal/server/dto/ModulationItem.java
+++ b/server/src/main/java/io/caudal/server/dto/ModulationItem.java
@@ -1,0 +1,17 @@
+package io.caudal.server.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.PositiveOrZero;
+
+public record ModulationItem(
+    @NotBlank String entity,
+    @PositiveOrZero double attention,
+    long decay
+) {
+
+    public ModulationItem {
+        if (decay < 0) {
+            decay = 0;
+        }
+    }
+}

--- a/server/src/main/java/io/caudal/server/service/SpaceManager.java
+++ b/server/src/main/java/io/caudal/server/service/SpaceManager.java
@@ -4,6 +4,7 @@ import io.caudal.core.BucketClock;
 import io.caudal.core.Event;
 import io.caudal.core.FocusItem;
 import io.caudal.core.MemoryEngine;
+import io.caudal.core.Modulation;
 import io.caudal.core.NextHopItem;
 import io.caudal.core.PathwayResult;
 import io.caudal.core.SpaceConfig;
@@ -42,6 +43,33 @@ public class SpaceManager {
             lock.writeLock().unlock();
         }
         return bucket;
+    }
+
+    public long applyEventsAndModulations(String spaceId, List<Event> events, List<Modulation> modulations) {
+        long bucket = clock.nowBucket();
+        ReadWriteLock lock = lockFor(spaceId);
+        lock.writeLock().lock();
+        try {
+            SpaceState space = spaces.computeIfAbsent(spaceId, id -> new SpaceState(id, defaultConfig));
+            engine.applyEvents(space, events, bucket);
+            if (modulations != null && !modulations.isEmpty()) {
+                engine.applyModulations(space, modulations);
+            }
+        } finally {
+            lock.writeLock().unlock();
+        }
+        return bucket;
+    }
+
+    public void applyModulations(String spaceId, List<Modulation> modulations) {
+        ReadWriteLock lock = lockFor(spaceId);
+        lock.writeLock().lock();
+        try {
+            SpaceState space = spaces.computeIfAbsent(spaceId, id -> new SpaceState(id, defaultConfig));
+            engine.applyModulations(space, modulations);
+        } finally {
+            lock.writeLock().unlock();
+        }
     }
 
     public List<FocusItem> focus(String spaceId, int k) {

--- a/server/src/main/resources/openapi/caudal-api.yaml
+++ b/server/src/main/resources/openapi/caudal-api.yaml
@@ -53,9 +53,9 @@ servers:
 tags:
   - name: Events
     description: |
-      Ingest interaction events into Caudal. Events are the only write
-      operation — everything else is derived. Events are durably persisted
-      to a write-ahead log before acknowledgment.
+      Write operations: ingest interaction events and apply attention
+      modulations. Events are the primary write — modulations provide
+      top-down attention control. Both are durably persisted.
   - name: Queries
     description: |
       Read the current state of a space's memory. All query endpoints are
@@ -105,6 +105,10 @@ paths:
                   dst: "tool:car-comparison"
                   intensity: 1.0
                   type: "tool_use"
+              modulations:
+                - entity: "topic:old-stuff"
+                  attention: 0.1
+                  decay: 50
       responses:
         '202':
           description: |
@@ -116,6 +120,65 @@ paths:
                 $ref: '#/components/schemas/EventResponse'
               example:
                 accepted: 2
+                asOf: "2026-02-28T10:05:00Z"
+        '400':
+          $ref: '#/components/responses/BadRequest'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  # -------------------------------------------------------
+  # POST /modulate
+  # -------------------------------------------------------
+  /modulate:
+    post:
+      operationId: modulate
+      tags: [Events]
+      summary: Apply attention modulations to a space
+      description: |
+        Applies top-down attention modulations to entities in the specified
+        space. Modulations suppress or amplify how much attention an entity
+        receives in query results (`/focus`, `/next`, `/pathways`) without
+        altering the underlying memory (edges).
+
+        **Key concepts:**
+        - `attention < 1.0` suppresses (e.g. `0.1` = 10% of normal score)
+        - `attention > 1.0` amplifies (e.g. `3.0` = triple the score)
+        - `attention = 1.0` resets any existing modulation (returns to normal)
+        - `decay` controls how many events until the modulation fades to half strength
+
+        **Metaphor:** Think of this as a teacher saying *"stop thinking about
+        bikes, focus on math."* The memory of bikes remains intact — only its
+        prominence in attention queries is reduced.
+
+        **Prefer embedding modulations in `POST /events`** when you are
+        already sending events. This endpoint exists for cases where you need
+        to modulate attention without any new events to emit.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ModulateRequest'
+            example:
+              space: "project:my-app"
+              modulations:
+                - entity: "topic:bikes"
+                  attention: 0.1
+                  decay: 50
+                - entity: "topic:math"
+                  attention: 3.0
+                  decay: 100
+      responses:
+        '200':
+          description: |
+            Modulations applied successfully. The response confirms how many
+            modulations were applied and the current server timestamp.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ModulateResponse'
+              example:
+                applied: 2
                 asOf: "2026-02-28T10:05:00Z"
         '400':
           $ref: '#/components/responses/BadRequest'
@@ -378,6 +441,19 @@ components:
             does not matter.
           items:
             $ref: '#/components/schemas/EventItem'
+        modulations:
+          type: array
+          description: |
+            Optional attention modulations to apply atomically with these
+            events. Modulations control top-down attention — suppressing
+            or amplifying how much specific entities appear in query
+            results — without altering the underlying memory (edges).
+
+            Including modulations here is equivalent to calling
+            `POST /modulate` separately, but avoids an extra network
+            round-trip. Modulations are applied after events are processed.
+          items:
+            $ref: '#/components/schemas/ModulationItem'
 
     EventItem:
       type: object
@@ -608,6 +684,106 @@ components:
             Ranges from `0.0` to `1.0`. A score of `0.34` means 34% of
             all walks traversed this specific sequence of entities.
           example: 0.34
+
+    # === Modulation ===
+
+    ModulationItem:
+      type: object
+      description: |
+        A top-down attention modulation for a single entity. Modulations
+        control how prominently an entity appears in query results without
+        altering the underlying memory (edges).
+
+        **Examples:**
+        - Suppress: `{"entity": "topic:bikes", "attention": 0.1, "decay": 50}`
+          — bikes' score drops to 10%, fading back to normal after ~50 events.
+        - Amplify: `{"entity": "topic:math", "attention": 3.0, "decay": 100}`
+          — math's score triples, fading back to normal after ~100 events.
+        - Reset: `{"entity": "topic:bikes", "attention": 1.0}`
+          — immediately removes any existing modulation for bikes.
+      required: [entity, attention]
+      properties:
+        entity:
+          type: string
+          minLength: 1
+          description: |
+            The entity to modulate. Must match an entity identifier used
+            in events (e.g. `topic:bikes`, `user:123`, `file:src/Main.java`).
+            If the entity does not exist yet, the modulation is stored and
+            takes effect when the entity appears in future events.
+          example: "topic:bikes"
+        attention:
+          type: number
+          format: double
+          description: |
+            Attention multiplier. Controls how much this entity's scores
+            are amplified or suppressed in query results (`/focus`, `/next`,
+            `/pathways`).
+
+            | Value | Effect |
+            |-------|--------|
+            | `0.0` | Fully suppress — entity will not appear in results |
+            | `0.1` | Strongly suppress — 10% of normal score |
+            | `1.0` | Neutral — no modulation (resets any existing modulation) |
+            | `2.0` | Double the entity's score |
+            | `5.0` | 5x amplification |
+
+            Must be non-negative. The underlying memory is never altered —
+            only the entity's visibility in queries changes.
+          example: 0.1
+        decay:
+          type: integer
+          format: int64
+          description: |
+            Number of events (across all entities in this space) until the
+            modulation fades to half its original strength. After `decay`
+            events, a modulation of `0.1` will be at `0.55` (halfway back
+            to `1.0`). After `2 * decay` events, it will be at `0.775`,
+            and so on — smoothly returning to neutral.
+
+            If omitted or set to `0`, the modulation persists indefinitely
+            until explicitly reset (by setting `attention` to `1.0`).
+          example: 50
+
+    ModulateRequest:
+      type: object
+      description: |
+        A request to apply attention modulations to entities in a space.
+        All modulations are applied atomically.
+      required: [space, modulations]
+      properties:
+        space:
+          type: string
+          minLength: 1
+          description: |
+            Target space identifier. The space is created implicitly if it
+            does not yet exist. Modulations are scoped to this space.
+          example: "project:my-app"
+        modulations:
+          type: array
+          minItems: 1
+          description: |
+            One or more attention modulations to apply. If multiple
+            modulations target the same entity, the last one wins.
+          items:
+            $ref: '#/components/schemas/ModulationItem'
+
+    ModulateResponse:
+      type: object
+      description: |
+        Acknowledgment returned after attention modulations are applied.
+      properties:
+        applied:
+          type: integer
+          format: int32
+          description: |
+            The number of modulations that were applied.
+          example: 2
+        asOf:
+          type: string
+          description: |
+            ISO-8601 instant representing the current server timestamp.
+          example: "2026-02-28T10:05:00Z"
 
     # === Errors ===
 

--- a/server/src/test/java/io/caudal/server/controller/EventControllerTest.java
+++ b/server/src/test/java/io/caudal/server/controller/EventControllerTest.java
@@ -73,6 +73,103 @@ class EventControllerTest {
     }
 
     @Test
+    void ingestEvents_withModulations_returnsAccepted() throws Exception {
+        mockMvc.perform(post("/api/v1/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "space": "mod-test",
+                      "events": [
+                        {"src": "user:alice", "dst": "topic:bikes", "intensity": 5.0},
+                        {"src": "user:alice", "dst": "topic:math", "intensity": 5.0}
+                      ],
+                      "modulations": [
+                        {"entity": "topic:bikes", "attention": 0.1, "decay": 50}
+                      ]
+                    }
+                    """))
+            .andExpect(status().isAccepted())
+            .andExpect(jsonPath("$.accepted").value(2));
+    }
+
+    @Test
+    void ingestEvents_withModulations_affectsFocus() throws Exception {
+        mockMvc.perform(post("/api/v1/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "space": "mod-focus-test",
+                      "events": [
+                        {"src": "user:x", "dst": "topic:suppress-me", "intensity": 5.0},
+                        {"src": "user:x", "dst": "topic:keep-me", "intensity": 5.0}
+                      ],
+                      "modulations": [
+                        {"entity": "topic:suppress-me", "attention": 0.0}
+                      ]
+                    }
+                    """))
+            .andExpect(status().isAccepted());
+
+        mockMvc.perform(get("/api/v1/focus")
+                .param("space", "mod-focus-test")
+                .param("k", "10"))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.items[?(@.id == 'topic:suppress-me')]").doesNotExist());
+    }
+
+    @Test
+    void modulate_standaloneEndpoint_returnsOk() throws Exception {
+        mockMvc.perform(post("/api/v1/events")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "space": "standalone-mod",
+                      "events": [{"src": "a", "dst": "b", "intensity": 1.0}]
+                    }
+                    """))
+            .andExpect(status().isAccepted());
+
+        mockMvc.perform(post("/api/v1/modulate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "space": "standalone-mod",
+                      "modulations": [
+                        {"entity": "b", "attention": 0.5, "decay": 100}
+                      ]
+                    }
+                    """))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.applied").value(1))
+            .andExpect(jsonPath("$.asOf").isNotEmpty());
+    }
+
+    @Test
+    void modulate_missingSpace_returns400() throws Exception {
+        mockMvc.perform(post("/api/v1/modulate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "modulations": [{"entity": "x", "attention": 0.5}]
+                    }
+                    """))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void modulate_emptyModulations_returns400() throws Exception {
+        mockMvc.perform(post("/api/v1/modulate")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""
+                    {
+                      "space": "test",
+                      "modulations": []
+                    }
+                    """))
+            .andExpect(status().isBadRequest());
+    }
+
+    @Test
     void ingestThenFocus_returnsIngested() throws Exception {
         mockMvc.perform(post("/api/v1/events")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/server/src/test/java/io/caudal/server/controller/QueryControllerTest.java
+++ b/server/src/test/java/io/caudal/server/controller/QueryControllerTest.java
@@ -114,6 +114,7 @@ class QueryControllerTest {
             .andReturn().getResponse().getContentAsString();
 
         org.assertj.core.api.Assertions.assertThat(response)
-            .doesNotContain("tau", "pheromone", "alpha", "decayPerBucket", "bucket", "ants", "maxSteps");
+            .doesNotContain("tau", "pheromone", "alpha", "decayPerBucket", "bucket",
+                    "ants", "maxSteps", "eventCounter", "appliedAtEventCount");
     }
 }

--- a/skills/caudal-attention/SKILL.md
+++ b/skills/caudal-attention/SKILL.md
@@ -169,6 +169,56 @@ Use pathway results to:
 - Understand why a topic is relevant (trace the path back)
 - Find non-obvious dependencies or related concepts
 
+## When to modulate attention
+
+Sometimes the right response isn't to emit more events — it's to directly
+control what gets attention. Use modulations when:
+
+| Situation | Action |
+|-----------|--------|
+| User says "let's move on from X" | Suppress X: `{"entity": "topic:X", "attention": 0.1, "decay": 50}` |
+| User explicitly prioritizes Y | Amplify Y: `{"entity": "topic:Y", "attention": 3.0, "decay": 50}` |
+| A topic keeps surfacing but is no longer relevant | Suppress it: `{"entity": "topic:stale", "attention": 0.0}` |
+| User returns to a previously-suppressed topic | Reset it: `{"entity": "topic:X", "attention": 1.0}` |
+
+**Embed modulations in your event calls** for zero extra latency:
+
+```bash
+curl -s -X POST "$CAUDAL_URL/api/v1/events" \
+  -H "Authorization: Bearer $CAUDAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "space": "'$SPACE'",
+    "events": [
+      {"src": "user:alice", "dst": "topic:math", "intensity": 5.0, "type": "discussion"}
+    ],
+    "modulations": [
+      {"entity": "topic:bikes", "attention": 0.1, "decay": 50}
+    ]
+  }'
+```
+
+Or use the standalone endpoint when you only need to steer attention:
+
+```bash
+curl -s -X POST "$CAUDAL_URL/api/v1/modulate" \
+  -H "Authorization: Bearer $CAUDAL_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "space": "'$SPACE'",
+    "modulations": [
+      {"entity": "topic:bikes", "attention": 0.1, "decay": 50},
+      {"entity": "topic:math", "attention": 3.0, "decay": 50}
+    ]
+  }'
+```
+
+**Key principles:**
+- Modulations are **top-down** — they don't change the memory, only what surfaces
+- A `decay` of 50 means the modulation fades to half-strength after 50 events
+- Omit `decay` (or set to 0) for persistent modulation until explicitly reset
+- Setting `attention: 1.0` removes the modulation entirely
+
 ## Integration pattern
 
 ### Setup: Check if Caudal is available

--- a/skills/caudal-attention/references/api-quick-ref.md
+++ b/skills/caudal-attention/references/api-quick-ref.md
@@ -8,7 +8,8 @@ All endpoints require: `Authorization: Bearer $CAUDAL_API_KEY`
 
 ## POST /events — Emit interaction events
 
-The only write operation. Everything else is derived.
+The primary write operation. Optionally includes attention modulations for
+zero-latency top-down control.
 
 **Request:**
 ```json
@@ -26,11 +27,18 @@ The only write operation. Everything else is derived.
         "sessionId": "sess-abc"
       }
     }
+  ],
+  "modulations": [
+    {
+      "entity": "topic:old-stuff",
+      "attention": 0.1,
+      "decay": 50
+    }
   ]
 }
 ```
 
-**Fields:**
+**Event fields:**
 
 | Field | Required | Default | Description |
 |-------|----------|---------|-------------|
@@ -42,6 +50,15 @@ The only write operation. Everything else is derived.
 | `events[].type` | no | null | Semantic label (chat, edit, tool_use, etc.) |
 | `events[].timestamp` | no | null | ISO-8601 original occurrence time (for auditing) |
 | `events[].attrs` | no | null | Free-form key-value metadata |
+
+**Modulation fields (optional):**
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `modulations` | no | — | Array of attention modulations to apply atomically with events |
+| `modulations[].entity` | yes | — | Entity to modulate (e.g. `topic:bikes`) |
+| `modulations[].attention` | yes | — | Multiplier: `0.0`=suppress, `1.0`=reset, `>1.0`=amplify |
+| `modulations[].decay` | no | 0 | Events until half-strength. `0`=persistent |
 
 **Response:** `202 Accepted`
 ```json
@@ -156,6 +173,51 @@ connections that single-hop queries cannot surface.
   "asOf": "2026-03-06T10:06:00Z"
 }
 ```
+
+---
+
+## POST /modulate — Suppress or amplify entity attention
+
+Directly control which entities surface in query results without changing the
+underlying memory. Use this when you only need to steer attention (no events
+to emit). For zero extra latency, prefer embedding modulations in `POST /events`.
+
+**Request:**
+```json
+{
+  "space": "project:my-app",
+  "modulations": [
+    {"entity": "topic:bikes", "attention": 0.1, "decay": 50},
+    {"entity": "topic:math", "attention": 3.0, "decay": 50}
+  ]
+}
+```
+
+**Fields:**
+
+| Field | Required | Default | Description |
+|-------|----------|---------|-------------|
+| `space` | yes | — | Space containing the entities |
+| `modulations` | yes | — | Array of modulations (at least one) |
+| `modulations[].entity` | yes | — | Entity to modulate |
+| `modulations[].attention` | yes | — | Multiplier: `0.0`=fully suppress, `0.1`=strongly suppress, `1.0`=reset (remove modulation), `3.0`=triple score |
+| `modulations[].decay` | no | 0 | Number of events until the modulation fades to half-strength. `0`=persistent until explicitly reset |
+
+**Response:** `200 OK`
+```json
+{
+  "applied": 2,
+  "asOf": "2026-03-06T10:06:00Z"
+}
+```
+
+**When to use modulate vs. embedded modulations:**
+
+| Scenario | Approach |
+|----------|----------|
+| Emitting events AND steering attention | Embed `modulations` in `POST /events` |
+| Only steering attention (no new events) | Use `POST /modulate` |
+| User says "stop thinking about X" | Either — whichever fits your current call |
 
 ---
 


### PR DESCRIPTION
Sometimes you need to tell Caudal "stop thinking about X, focus on Y" without erasing the memory of X. Attention modulation lets you suppress or amplify how much an entity appears in query results.