### PR TITLE
feat(examples): add API client demos in multiple languages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,12 @@ logs/
 
 # === Spring Boot ===
 spring-shell.log
+
+# === Examples build artifacts ===
+examples/scala/.bsp/
+examples/scala/.scala-build/
+examples/scala/.bloop/
+examples/java/out/
+examples/python/__pycache__/
+examples/js/node_modules/
+examples/js/dist/

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -17,7 +17,7 @@ javac --release 21 -d out src/caudal/examples/CaudalDemo.java
 java -cp out caudal.examples.CaudalDemo
 
 # Or with environment variables
-CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme java -cp caudal/examples caudal.examples.CaudalDemo
+CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme java -cp out caudal.examples.CaudalDemo
 ```
 
 ## Configuration

--- a/examples/java/README.md
+++ b/examples/java/README.md
@@ -1,0 +1,40 @@
+# Caudal API Demo (Java)
+
+A Java 21 implementation of the Caudal API demo using `java.net.http.HttpClient`.
+
+## Prerequisites
+
+- Java 21 or later
+
+## Quick Start
+
+```bash
+# Compile
+cd examples/java && mkdir out
+javac --release 21 -d out src/caudal/examples/CaudalDemo.java
+
+# Run with defaults
+java -cp out caudal.examples.CaudalDemo
+
+# Or with environment variables
+CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme java -cp caudal/examples caudal.examples.CaudalDemo
+```
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `CAUDAL_URL` | `http://localhost:8080` | Base URL of Caudal server |
+| `CAUDAL_API_KEY` | `changeme` | API key for authentication |
+
+## Features
+
+- Ingest events into the `demo` space
+- Query focus items
+- Get next hops from a source node
+- Calculate pathways from a starting node
+- Health check
+
+## Dependencies
+
+None — uses only standard library classes (`java.net.http.HttpClient`, built-in JSON formatting).

--- a/examples/java/src/caudal/examples/CaudalDemo.java
+++ b/examples/java/src/caudal/examples/CaudalDemo.java
@@ -1,0 +1,141 @@
+package caudal.examples;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+
+public class CaudalDemo {
+
+    public static void main(String[] args) {
+        String baseUrl = System.getenv().getOrDefault("CAUDAL_URL", "http://localhost:8080");
+        String apiKey = System.getenv().getOrDefault("CAUDAL_API_KEY", "changeme");
+
+        HttpClient client = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(10))
+                .build();
+
+        String authHeader = "Bearer " + apiKey;
+
+        try {
+            prettyPrint("Ingest events", post(client, URI.create(baseUrl + "/api/v1/events"), authHeader,
+                    """
+                    {
+                        "space": "demo",
+                        "events": [
+                            {"src": "user:alice", "dst": "topic:machine-learning", "intensity": 3.0, "type": "interaction"},
+                            {"src": "user:alice", "dst": "topic:python", "intensity": 2.0, "type": "interaction"},
+                            {"src": "user:bob", "dst": "topic:machine-learning", "intensity": 5.0, "type": "interaction"},
+                            {"src": "user:bob", "dst": "topic:data-pipelines", "intensity": 1.0, "type": "interaction"},
+                            {"src": "user:carol", "dst": "topic:python", "intensity": 4.0, "type": "interaction"},
+                            {"src": "user:carol", "dst": "topic:machine-learning", "intensity": 1.0, "type": "interaction"}
+                        ]
+                    }
+                    """));
+
+            prettyPrint("Focus (what matters now?)",
+                    get(client, URI.create(baseUrl + "/api/v1/focus?space=demo&k=5"), authHeader));
+
+            prettyPrint("Next hops from user:alice",
+                    get(client, URI.create(baseUrl + "/api/v1/next?space=demo&src=user:alice&k=5"), authHeader));
+
+            prettyPrint("Pathways from user:bob", post(client, URI.create(baseUrl + "/api/v1/pathways"), authHeader,
+                    """
+                    {
+                        "space": "demo",
+                        "start": "user:bob",
+                        "k": 5,
+                        "mode": "balanced"
+                    }
+                    """));
+
+            prettyPrint("Health", get(client, URI.create(baseUrl + "/actuator/health"), authHeader));
+
+            System.out.println();
+
+        } catch (Exception e) {
+            System.err.println("Error: " + e.getMessage());
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    private static String get(HttpClient client, URI uri, String authHeader) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(uri)
+                .header("Authorization", authHeader)
+                .GET()
+                .build();
+        return sendRequest(client, request);
+    }
+
+    private static String post(HttpClient client, URI uri, String authHeader, String body) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(uri)
+                .header("Authorization", authHeader)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        return sendRequest(client, request);
+    }
+
+    private static String sendRequest(HttpClient client, HttpRequest request) throws Exception {
+        HttpResponse<String> response = client.send(request, HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= 400) {
+            throw new RuntimeException("HTTP " + response.statusCode() + ": " + response.body());
+        }
+        return response.body();
+    }
+
+    private static void prettyPrint(String label, String json) {
+        System.out.println("\n=== " + label + " ===");
+        System.out.println(formatJson(json));
+    }
+
+    private static String formatJson(String json) {
+        StringBuilder result = new StringBuilder();
+        int indent = 0;
+        boolean inString = false;
+
+        for (int i = 0; i < json.length(); i++) {
+            char c = json.charAt(i);
+
+            if (c == '"' && (i == 0 || json.charAt(i - 1) != '\\')) {
+                inString = !inString;
+                result.append(c);
+            } else if (!inString) {
+                switch (c) {
+                    case '{', '[' -> {
+                        result.append(c);
+                        result.append('\n');
+                        indent += 2;
+                        result.append(" ".repeat(indent));
+                    }
+                    case '}', ']' -> {
+                        result.append('\n');
+                        indent -= 2;
+                        result.append(" ".repeat(indent));
+                        result.append(c);
+                    }
+                    case ',' -> {
+                        result.append(c);
+                        result.append('\n');
+                        result.append(" ".repeat(indent));
+                    }
+                    case ':' -> result.append(": ");
+                    default -> {
+                        if (!Character.isWhitespace(c)) {
+                            result.append(c);
+                        }
+                    }
+                }
+            } else {
+                result.append(c);
+            }
+        }
+        return result.toString();
+    }
+}

--- a/examples/js/CaudalDemo.js
+++ b/examples/js/CaudalDemo.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+/**
+ * Caudal API demo — run against a local instance
+ * Usage: node CaudalDemo.js [base_url] [api_key]
+ * Or set environment variables: CAUDAL_URL, CAUDAL_API_KEY
+ */
+
+const BASE_URL = process.env.CAUDAL_URL || process.argv[2] || "http://localhost:8080";
+const API_KEY = process.env.CAUDAL_API_KEY || process.argv[3] || "changeme";
+
+const headers = {
+  Authorization: `Bearer ${API_KEY}`,
+  "Content-Type": "application/json",
+};
+
+async function get(url) {
+  const response = await fetch(url, { method: "GET", headers });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+  }
+  return response.json();
+}
+
+async function post(url, body) {
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+  }
+  return response.json();
+}
+
+function prettyPrint(label, data) {
+  console.log(`\n=== ${label} ===`);
+  console.log(JSON.stringify(data, null, 2));
+}
+
+async function main() {
+  try {
+    const eventsPayload = {
+      space: "demo",
+      events: [
+        { src: "user:alice", dst: "topic:machine-learning", intensity: 3.0, type: "interaction" },
+        { src: "user:alice", dst: "topic:python", intensity: 2.0, type: "interaction" },
+        { src: "user:bob", dst: "topic:machine-learning", intensity: 5.0, type: "interaction" },
+        { src: "user:bob", dst: "topic:data-pipelines", intensity: 1.0, type: "interaction" },
+        { src: "user:carol", dst: "topic:python", intensity: 4.0, type: "interaction" },
+        { src: "user:carol", dst: "topic:machine-learning", intensity: 1.0, type: "interaction" },
+      ],
+    };
+    prettyPrint("Ingest events", await post(`${BASE_URL}/api/v1/events`, eventsPayload));
+
+    prettyPrint("Focus (what matters now?)", await get(`${BASE_URL}/api/v1/focus?space=demo&k=5`));
+
+    prettyPrint("Next hops from user:alice", await get(`${BASE_URL}/api/v1/next?space=demo&src=user:alice&k=5`));
+
+    const pathwaysPayload = { space: "demo", start: "user:bob", k: 5, mode: "balanced" };
+    prettyPrint("Pathways from user:bob", await post(`${BASE_URL}/api/v1/pathways`, pathwaysPayload));
+
+    prettyPrint("Health", await get(`${BASE_URL}/actuator/health`));
+
+    console.log();
+  } catch (error) {
+    console.error(`Error: ${error.message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/examples/js/CaudalDemo.ts
+++ b/examples/js/CaudalDemo.ts
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+/**
+ * Caudal API demo — run against a local instance
+ * Usage: npx tsx CaudalDemo.ts [base_url] [api_key]
+ * Or set environment variables: CAUDAL_URL, CAUDAL_API_KEY
+ */
+
+interface EventItem {
+  src: string;
+  dst: string;
+  intensity: number;
+  type: string;
+}
+
+interface EventsPayload {
+  space: string;
+  events: EventItem[];
+}
+
+interface PathwayPayload {
+  space: string;
+  start: string;
+  k: number;
+  mode: string;
+}
+
+const BASE_URL = process.env.CAUDAL_URL || process.argv[2] || "http://localhost:8080";
+const API_KEY = process.env.CAUDAL_API_KEY || process.argv[3] || "changeme";
+
+const headers = {
+  Authorization: `Bearer ${API_KEY}`,
+  "Content-Type": "application/json",
+};
+
+async function get<T>(url: string): Promise<T> {
+  const response = await fetch(url, { method: "GET", headers });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+async function post<T>(url: string, body: unknown): Promise<T> {
+  const response = await fetch(url, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(body),
+  });
+  if (!response.ok) {
+    throw new Error(`HTTP ${response.status}: ${await response.text()}`);
+  }
+  return response.json() as Promise<T>;
+}
+
+function prettyPrint<T>(label: string, data: T): void {
+  console.log(`\n=== ${label} ===`);
+  console.log(JSON.stringify(data, null, 2));
+}
+
+async function main(): Promise<void> {
+  try {
+    const eventsPayload: EventsPayload = {
+      space: "demo",
+      events: [
+        { src: "user:alice", dst: "topic:machine-learning", intensity: 3.0, type: "interaction" },
+        { src: "user:alice", dst: "topic:python", intensity: 2.0, type: "interaction" },
+        { src: "user:bob", dst: "topic:machine-learning", intensity: 5.0, type: "interaction" },
+        { src: "user:bob", dst: "topic:data-pipelines", intensity: 1.0, type: "interaction" },
+        { src: "user:carol", dst: "topic:python", intensity: 4.0, type: "interaction" },
+        { src: "user:carol", dst: "topic:machine-learning", intensity: 1.0, type: "interaction" },
+      ],
+    };
+    prettyPrint("Ingest events", await post(`${BASE_URL}/api/v1/events`, eventsPayload));
+
+    prettyPrint("Focus (what matters now?)", await get(`${BASE_URL}/api/v1/focus?space=demo&k=5`));
+
+    prettyPrint("Next hops from user:alice", await get(`${BASE_URL}/api/v1/next?space=demo&src=user:alice&k=5`));
+
+    const pathwaysPayload: PathwayPayload = { space: "demo", start: "user:bob", k: 5, mode: "balanced" };
+    prettyPrint("Pathways from user:bob", await post(`${BASE_URL}/api/v1/pathways`, pathwaysPayload));
+
+    prettyPrint("Health", await get(`${BASE_URL}/actuator/health`));
+
+    console.log();
+  } catch (error) {
+    console.error(`Error: ${(error as Error).message}`);
+    process.exit(1);
+  }
+}
+
+main();

--- a/examples/js/README.md
+++ b/examples/js/README.md
@@ -13,13 +13,13 @@ JavaScript and TypeScript implementations of the Caudal API demo using native `f
 
 ```bash
 # Run with defaults
-node caudal/examples/js/CaudalDemo.js
+node examples/js/CaudalDemo.js
 
 # Or with arguments
-node caudal/examples/js/CaudalDemo.js http://localhost:8080 changeme
+node examples/js/CaudalDemo.js http://localhost:8080 changeme
 
 # Or with environment variables
-CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme node caudal/examples/js/CaudalDemo.js
+CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme node examples/js/CaudalDemo.js
 ```
 
 ### TypeScript
@@ -29,13 +29,13 @@ CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme node caudal/examples/js
 npm install --save-dev typescript @types/node tsx
 
 # Run with defaults
-npx tsx caudal/examples/js/CaudalDemo.ts
+npx tsx examples/js/CaudalDemo.ts
 
 # Or with arguments
-npx tsx caudal/examples/js/CaudalDemo.ts http://localhost:8080 changeme
+npx tsx examples/js/CaudalDemo.ts http://localhost:8080 changeme
 
 # Or with environment variables
-CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme npx tsx caudal/examples/js/CaudalDemo.ts
+CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme npx tsx examples/js/CaudalDemo.ts
 ```
 
 ## Configuration

--- a/examples/js/README.md
+++ b/examples/js/README.md
@@ -1,0 +1,65 @@
+# Caudal API Demo (JavaScript/TypeScript)
+
+JavaScript and TypeScript implementations of the Caudal API demo using native `fetch`.
+
+## Prerequisites
+
+- **JavaScript**: Node.js 18+ (native fetch)
+- **TypeScript**: Node.js 18+, TypeScript, and `tsx` or `ts-node`
+
+## Quick Start
+
+### JavaScript
+
+```bash
+# Run with defaults
+node caudal/examples/js/CaudalDemo.js
+
+# Or with arguments
+node caudal/examples/js/CaudalDemo.js http://localhost:8080 changeme
+
+# Or with environment variables
+CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme node caudal/examples/js/CaudalDemo.js
+```
+
+### TypeScript
+
+```bash
+# Install TypeScript and types
+npm install --save-dev typescript @types/node tsx
+
+# Run with defaults
+npx tsx caudal/examples/js/CaudalDemo.ts
+
+# Or with arguments
+npx tsx caudal/examples/js/CaudalDemo.ts http://localhost:8080 changeme
+
+# Or with environment variables
+CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme npx tsx caudal/examples/js/CaudalDemo.ts
+```
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `CAUDAL_URL` | `http://localhost:8080` | Base URL of Caudal server |
+| `CAUDAL_API_KEY` | `changeme` | API key for authentication |
+
+## Features
+
+- Ingest events into the `demo` space
+- Query focus items
+- Get next hops from a source node
+- Calculate pathways from a starting node
+- Health check
+
+## TypeScript Benefits
+
+- Full type safety with interfaces
+- Generic typed HTTP functions
+- Better IDE support and autocomplete
+
+## Dependencies
+
+**JavaScript**: None (uses native `fetch`)  
+**TypeScript**: `typescript`, `@types/node`, `tsx` (for running)

--- a/examples/python/CaudalDemo.py
+++ b/examples/python/CaudalDemo.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""
+Caudal API demo — run against a local instance
+Usage: python CaudalDemo.py [base_url] [api_key]
+Or set environment variables: CAUDAL_URL, CAUDAL_API_KEY
+"""
+
+import json
+import os
+import sys
+from urllib.parse import urlencode
+
+import requests
+
+
+def get_base_url_and_key() -> tuple[str, str]:
+    """Get base URL and API key from args or environment."""
+    base_url = os.environ.get("CAUDAL_URL", "http://localhost:8080")
+    api_key = os.environ.get("CAUDAL_API_KEY", "changeme")
+
+    if len(sys.argv) > 1:
+        base_url = sys.argv[1]
+    if len(sys.argv) > 2:
+        api_key = sys.argv[2]
+
+    return base_url, api_key
+
+
+def get(client: requests.Session, url: str, headers: dict) -> dict:
+    """Send GET request and return JSON response."""
+    response = client.get(url, headers=headers)
+    response.raise_for_status()
+    return response.json()
+
+
+def post(client: requests.Session, url: str, headers: dict, data: dict) -> dict:
+    """Send POST request with JSON body and return JSON response."""
+    response = client.post(url, headers=headers, json=data)
+    response.raise_for_status()
+    return response.json()
+
+
+def pretty_print(label: str, data: dict) -> None:
+    """Print label with formatted JSON."""
+    print(f"\n=== {label} ===")
+    print(json.dumps(data, indent=2))
+
+
+def main() -> None:
+    base_url, api_key = get_base_url_and_key()
+    headers = {"Authorization": f"Bearer {api_key}"}
+
+    client = requests.Session()
+
+    try:
+        events_payload = {
+            "space": "demo",
+            "events": [
+                {
+                    "src": "user:alice",
+                    "dst": "topic:machine-learning",
+                    "intensity": 3.0,
+                    "type": "interaction",
+                },
+                {
+                    "src": "user:alice",
+                    "dst": "topic:python",
+                    "intensity": 2.0,
+                    "type": "interaction",
+                },
+                {
+                    "src": "user:bob",
+                    "dst": "topic:machine-learning",
+                    "intensity": 5.0,
+                    "type": "interaction",
+                },
+                {
+                    "src": "user:bob",
+                    "dst": "topic:data-pipelines",
+                    "intensity": 1.0,
+                    "type": "interaction",
+                },
+                {
+                    "src": "user:carol",
+                    "dst": "topic:python",
+                    "intensity": 4.0,
+                    "type": "interaction",
+                },
+                {
+                    "src": "user:carol",
+                    "dst": "topic:machine-learning",
+                    "intensity": 1.0,
+                    "type": "interaction",
+                },
+            ],
+        }
+        pretty_print(
+            "Ingest events",
+            post(client, f"{base_url}/api/v1/events", headers, events_payload),
+        )
+
+        pretty_print(
+            "Focus (what matters now?)",
+            get(client, f"{base_url}/api/v1/focus?space=demo&k=5", headers),
+        )
+
+        pretty_print(
+            "Next hops from user:alice",
+            get(
+                client, f"{base_url}/api/v1/next?space=demo&src=user:alice&k=5", headers
+            ),
+        )
+
+        pathways_payload = {
+            "space": "demo",
+            "start": "user:bob",
+            "k": 5,
+            "mode": "balanced",
+        }
+        pretty_print(
+            "Pathways from user:bob",
+            post(client, f"{base_url}/api/v1/pathways", headers, pathways_payload),
+        )
+
+        pretty_print("Health", get(client, f"{base_url}/actuator/health", headers))
+
+        print()
+
+    except requests.exceptions.HTTPError as e:
+        print(f"HTTP Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except requests.exceptions.ConnectionError as e:
+        print(f"Connection Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    finally:
+        client.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -1,0 +1,48 @@
+# Caudal API Demo (Python)
+
+A Python implementation of the Caudal API demo using the `requests` library.
+
+## Prerequisites
+
+- Python 3.10+
+- `requests` library
+
+## Quick Start
+
+```bash
+# Install requests if needed
+pip install requests
+
+# Run with defaults
+python caudal/examples/python/CaudalDemo.py
+
+# Or with arguments
+python caudal/examples/python/CaudalDemo.py http://localhost:8080 changeme
+
+# Or with environment variables
+CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme python caudal/examples/python/CaudalDemo.py
+```
+Or with [uv](https://docs.astral.sh/uv/getting-started/installation/):
+
+``` bash
+uv run --with requests examples/python/CaudalDemo.py
+```
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `CAUDAL_URL` | `http://localhost:8080` | Base URL of Caudal server |
+| `CAUDAL_API_KEY` | `changeme` | API key for authentication |
+
+## Features
+
+- Ingest events into the `demo` space
+- Query focus items
+- Get next hops from a source node
+- Calculate pathways from a starting node
+- Health check
+
+## Dependencies
+
+- `requests` - HTTP client

--- a/examples/python/README.md
+++ b/examples/python/README.md
@@ -14,13 +14,13 @@ A Python implementation of the Caudal API demo using the `requests` library.
 pip install requests
 
 # Run with defaults
-python caudal/examples/python/CaudalDemo.py
+python examples/python/CaudalDemo.py
 
 # Or with arguments
-python caudal/examples/python/CaudalDemo.py http://localhost:8080 changeme
+python examples/python/CaudalDemo.py http://localhost:8080 changeme
 
 # Or with environment variables
-CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme python caudal/examples/python/CaudalDemo.py
+CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme python examples/python/CaudalDemo.py
 ```
 Or with [uv](https://docs.astral.sh/uv/getting-started/installation/):
 

--- a/examples/scala/CaudalDemo.scala
+++ b/examples/scala/CaudalDemo.scala
@@ -1,0 +1,81 @@
+//> using scala "3.5.2"
+//> using dep "com.softwaremill.sttp.client3::core:3.9.8"
+//> using dep "com.softwaremill.sttp.client3::circe:3.9.8"
+//> using dep "io.circe::circe-generic:0.14.6"
+
+package caudal.examples
+
+import sttp.client3.*
+import sttp.client3.circe.*
+import sttp.model.Uri
+import io.circe.*
+import io.circe.generic.auto.*
+import io.circe.syntax.*
+
+object CaudalDemo extends App:
+
+  val baseUrl = sys.env.getOrElse("CAUDAL_URL", "http://localhost:8080")
+  val apiKey  = sys.env.getOrElse("CAUDAL_API_KEY", "changeme")
+
+  private given Backend: SttpBackend[Identity, Any] = HttpURLConnectionBackend()
+
+  private def authHeader: Map[String, String] = 
+    Map("Authorization" -> s"Bearer $apiKey")
+
+  private def post[T: Encoder.AsRoot](uri: Uri, body: T): String =
+    val request = basicRequest
+      .post(uri)
+      .headers(authHeader)
+      .contentType("application/json")
+      .body(body.asJson.noSpaces)
+    request.send().body.fold(sys.error, identity)
+
+  private def get(uri: Uri): String =
+    val request = basicRequest
+      .get(uri)
+      .headers(authHeader)
+    request.send().body.fold(sys.error, identity)
+
+  private def prettyPrint(label: String, json: String): Unit =
+    println(s"\n=== $label ===")
+    io.circe.jawn.decode[Json](json).foreach: j =>
+      println(j.printWith(Printer.spaces2))
+
+  val eventsUri   = Uri.parse(s"$baseUrl/api/v1/events").getOrElse(sys.error("Invalid URI"))
+  val focusUri    = Uri.parse(s"$baseUrl/api/v1/focus").getOrElse(sys.error("Invalid URI"))
+  val nextUri     = Uri.parse(s"$baseUrl/api/v1/next").getOrElse(sys.error("Invalid URI"))
+  val pathwaysUri = Uri.parse(s"$baseUrl/api/v1/pathways").getOrElse(sys.error("Invalid URI"))
+  val healthUri   = Uri.parse(s"$baseUrl/actuator/health").getOrElse(sys.error("Invalid URI"))
+
+  val ingestRequest = IngestRequest(
+    space = "demo",
+    events = List(
+      EventItem(src = "user:alice",   dst = "topic:machine-learning", intensity = 3.0, `type` = "interaction"),
+      EventItem(src = "user:alice",   dst = "topic:python",            intensity = 2.0, `type` = "interaction"),
+      EventItem(src = "user:bob",     dst = "topic:machine-learning", intensity = 5.0, `type` = "interaction"),
+      EventItem(src = "user:bob",     dst = "topic:data-pipelines",   intensity = 1.0, `type` = "interaction"),
+      EventItem(src = "user:carol",   dst = "topic:python",            intensity = 4.0, `type` = "interaction"),
+      EventItem(src = "user:carol",   dst = "topic:machine-learning", intensity = 1.0, `type` = "interaction")
+    )
+  )
+
+  prettyPrint("Ingest events", post(eventsUri, ingestRequest))
+
+  prettyPrint("Focus (what matters now?)", 
+    get(focusUri.withParams(Map("space" -> "demo", "k" -> "5"))))
+
+  prettyPrint("Next hops from user:alice", 
+    get(nextUri.withParams(Map("space" -> "demo", "src" -> "user:alice", "k" -> "5"))))
+
+  val pathwaysRequest = PathwayQuery(space = "demo", start = "user:bob", k = 5, mode = "balanced")
+  prettyPrint("Pathways from user:bob", post(pathwaysUri, pathwaysRequest))
+
+  prettyPrint("Health", get(healthUri))
+
+  println()
+
+end CaudalDemo
+
+case class IngestRequest(space: String, events: List[EventItem])
+case class EventItem(src: String, dst: String, intensity: Double, `type`: String = "interaction")
+case class PathwayQuery(space: String, start: String, k: Int, mode: String)

--- a/examples/scala/README.md
+++ b/examples/scala/README.md
@@ -1,0 +1,38 @@
+# Caudal API Demo (Scala 3)
+
+A Scala 3 implementation of the Caudal API demo using [scala-cli](https://scala-cli.virtuslab.org/).
+
+## Prerequisites
+
+- [scala-cli](https://scala-cli.virtuslab.org/) installed
+
+## Quick Start
+
+```bash
+# Run with defaults (http://localhost:8080, API key: changeme)
+scala-cli run CaudalDemo.scala
+
+# Or with environment variables
+CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme scala-cli run CaudalDemo.scala
+```
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|---------------------|---------|-------------|
+| `CAUDAL_URL` | `http://localhost:8080` | Base URL of Caudal server |
+| `CAUDAL_API_KEY` | `changeme` | API key for authentication |
+
+## Features
+
+- Ingest events into the `demo` space
+- Query focus items
+- Get next hops from a source node
+- Calculate pathways from a starting node
+- Health check
+
+## Dependencies
+
+Managed by scala-cli using directives:
+- `sttp.client3` - HTTP client
+- `circe` - JSON handling

--- a/examples/scala/README.md
+++ b/examples/scala/README.md
@@ -10,10 +10,10 @@ A Scala 3 implementation of the Caudal API demo using [scala-cli](https://scala-
 
 ```bash
 # Run with defaults (http://localhost:8080, API key: changeme)
-scala-cli run CaudalDemo.scala
+scala-cli run examples/scala/CaudalDemo.scala
 
 # Or with environment variables
-CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme scala-cli run CaudalDemo.scala
+CAUDAL_URL=http://localhost:8080 CAUDAL_API_KEY=changeme scala-cli run examples/scala/CaudalDemo.scala
 ```
 
 ## Configuration


### PR DESCRIPTION
Add Caudal API demo implementations:
- Scala 3 with sttp and circe
- Java with HttpClient
- Python with requests
- JavaScript with native fetch
- TypeScript with interfaces

Closes #16.